### PR TITLE
Update/across session creds

### DIFF
--- a/MemoryTokenStore.js
+++ b/MemoryTokenStore.js
@@ -3,12 +3,48 @@ class MemoryTokenStore {
     this._store = new Map();
   }
 
-  get(canvasId) {
-    return Promise.resolve(this._store.get(canvasId));
+  /**
+   * Get the tokens for a user
+   * @param {number} canvasId - the canvasId for the user to look up
+   * @return {object} token object in the following form:
+   *   { refreshToken, accessToken, accessTokenExpiry } where refreshToken and
+   *   accessToken are string tokens and accessTokenExpiry is a ms since epoch
+   *   expiry timestamp for the accessToken. The refreshToken is assumed to not
+   *   expire OR returns {} if no entry yet.
+   */
+  async get(canvasId) {
+    return this._store.get(canvasId) || {};
   }
 
-  set(canvasId, refreshToken) {
-    this._store.set(canvasId, refreshToken);
+  /**
+   * Store tokens for a user
+   * @param {number} canvasId - the canvasId for the user to store tokens for
+   * @param {object} tokens - an object containing all token info to update
+   * @param {string} [tokens.refreshToken] - if included, updates the user's
+   *   current value for their refreshToken
+   * @param {string} [tokens.accessToken] - if included, updates the user's
+   *   current value for their accessToken
+   * @param {number} [tokens.accessTokenExpiry] - if included, updates the
+   *   user's current accessToken expiry
+   */
+  async set(canvasId, tokens) {
+    // First get the user's current info
+    const prevTokens = await this.get(canvasId);
+
+    // Merge values
+    const newTokens = {
+      refreshToken: tokens.refreshToken || prevTokens.refreshToken,
+      accessToken: tokens.accessToken || prevTokens.accessToken,
+      accessTokenExpiry: (
+        tokens.accessTokenExpiry
+        || prevTokens.accessTokenExpiry
+      ),
+    };
+
+    // Store
+    this._store.set(canvasId, newTokens);
+
+    // Return resolve
     return Promise.resolve();
   }
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ initAuthorization({
 // TODO: add routes to express app
 ```
 
-To authorize a user, redirect them to the `launchPath` via GET. `caccl-authorizer` will handle the entire authorization process then redirect them to the `defaultAuthorizedRedirect` path. After authorization, the user's access token will appear in their session: `req.session.accessToken`.
+To authorize a user, redirect them to the `launchPath` via GET. `caccl-authorizer` will handle the entire authorization process then redirect them to the `defaultAuthorizedRedirect` path. After authorization, the user's access token will appear in the `req` object: `req.accessToken`.
 
 **Important:** you must initialize `caccl-authorizer` before adding refreshed routes (see `autoRefreshRoutes` below).
 

--- a/docs/TokenStore.md
+++ b/docs/TokenStore.md
@@ -4,21 +4,37 @@ Your custom token store object will be designed to replace the built-in memory s
 
 ## Methods
 
-### get(key)
+### async get(key)
+
+Get the tokens for a user
+ * @param {number} canvasId -
+ * @return {object}
+ */
 
 Argument | Type | Description
 :--- | :--- | :---
-key | string | the storage key
+canvasId | number | the canvasId for the user to look up
 
-Returns:  
-`Promise` that resolves with the value associated with the given key.
+Returns:
 
-### set(key, value)
+token object in the following form: `{ refreshToken, accessToken, accessTokenExpiry }` where refreshToken and accessToken are string tokens and accessTokenExpiry is a ms since epoch expiry timestamp for the accessToken. The refreshToken is assumed to not expire
+
+### async set(canvasId, tokens)
+
+Store tokens for a user
 
 Argument | Type | Description
 :--- | :--- | :---
-key | string | the storage key
-value | string | the value to store
+canvasId | number | the canvasId for the user to store tokens for
+tokens | object | an object containing all token info to update
+
+Allowed properties for tokens:
+
+Argument | Type | Description
+:--- | :--- | :---
+tokens.refreshToken | string | if included, updates the user's current value for their refreshToken
+tokens.accessToken | string | if included, updates the user's current value for their accessToken
+tokens.accessTokenExpiry | number | if included, updates the user's current accessToken expiry
 
 Returns:  
 `Promise` that resolves when the store is successful.

--- a/genLTILaunch.js
+++ b/genLTILaunch.js
@@ -1,11 +1,20 @@
 const randomstring = require('randomstring');
 
+/**
+ * Replace all occurrences in a string
+ * @author Gabe Abrams
+ * @param {string} str - the string to search
+ * @param {string} search - the fragment to search for
+ * @param {string} replacement - the fragment to replace when search is found
+ * @return {string} the string with its replacements made
+ */
 const replaceAll = (str, search, replacement) => {
   return str.replace(new RegExp(search, 'g'), replacement);
 };
 
 /**
  * Generates an LTI launch body
+ * @author Gabe Abrams
  * @param {object} profile - the Canvas profile of the user that is being
  *   launched
  * @param {object} course - the Canvas course the user is launching from
@@ -20,12 +29,14 @@ const replaceAll = (str, search, replacement) => {
  *   external tool assignment launch based on this assignment
  */
 module.exports = (options) => {
+  // Get the first and last name from the profile
   const [last, first] = options.profile.sortable_name.split(', ');
 
   // Prep roles
   const extRoles = [];
   const roles = [];
   if (Array.isArray(options.course.enrollments)) {
+    // Add student enrollment if applicable
     const hasStudentEnrollment = (
       options.course.enrollments.some((enrollment) => {
         return enrollment.type === 'student';
@@ -40,6 +51,7 @@ module.exports = (options) => {
       roles.push('Learner');
     }
 
+    // Add teacher enrollment if applicable
     const hasTeacherEnrollment = (
       options.course.enrollments.some((enrollment) => {
         return enrollment.type === 'teacher';

--- a/index.js
+++ b/index.js
@@ -676,7 +676,7 @@ module.exports = (config) => {
     // Create API
     const api = new API({
       canvasHost,
-      accessToken: req.session.accessToken,
+      accessToken: req.accessToken,
       cacheType: null,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-authorizer",
-  "version": "1.0.47",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-authorizer",
-  "version": "1.0.47",
+  "version": "1.1.0",
   "description": "Acquires Canvas tokens through via OAuth, stores refresh tokens, and refreshes access tokens when they expire.",
   "main": "index.js",
   "scripts": {

--- a/test/helpers/addAppRoutes.js
+++ b/test/helpers/addAppRoutes.js
@@ -48,21 +48,16 @@ module.exports = (app, config) => {
   // Verify that API is working
   app.get('/withapi/verifyapi', async (req, res) => {
     // Make sure we have the correct session param
-    if (
-      !req.session
-      || !req.session.accessToken
-      || !req.session.refreshToken
-      || !req.session.accessTokenExpiry
-    ) {
+    if (!req.accessToken) {
       return res.json({
         success: false,
-        message: `Required: accessToken, refreshToken, and accessTokenExpiry in session. Instead, seassion was: ${req.session}`,
+        message: `Required: accessToken. Instead, seassion was: ${req.accessToken}`,
       });
     }
 
     // Make sure token hasn't expired
     const elapsedSinceExpiry = (
-      req.session.accessTokenExpiry < Date.now()
+      req.accessTokenExpiry < Date.now()
     );
     if (elapsedSinceExpiry > 0) {
       return res.json({
@@ -74,7 +69,7 @@ module.exports = (app, config) => {
     // Try to use the access token to get user's profile
     const api = new API({
       canvasHost,
-      accessToken: req.session.accessToken,
+      accessToken: req.accessToken,
     });
     // Attempt to get user's profile
     try {
@@ -139,7 +134,7 @@ module.exports = (app, config) => {
   // Route that immediately expires the current access token
   app.get('/expirenow', (req, res) => {
     // Set as expired (expiration is now):
-    req.session.accessTokenExpiry = Date.now();
+    req.accessTokenExpiry = Date.now();
 
     // Save session
     req.session.save((err) => {
@@ -150,7 +145,7 @@ module.exports = (app, config) => {
   // Check how long till token expires
   app.get('/tokentimeleft', (req, res) => {
     return res.json({
-      ms: req.session.accessTokenExpiry - Date.now(),
+      ms: req.accessTokenExpiry - Date.now(),
     });
   });
 


### PR DESCRIPTION
This is part of a large across-caccl change to switch access tokens from being in the session to being in the tokenStore. This will solve token race conditions between sessions of the same user and will make it possible for users to be logged into the same app on different machines without causing issues with Canvas, though this does make it possible for users to get closer to throttling limits.