### PR TITLE
GATHR-184 parse additional LTI LIS course sourceId

### DIFF
--- a/genLTILaunch.js
+++ b/genLTILaunch.js
@@ -102,6 +102,7 @@ module.exports = (options) => {
   body.lis_person_name_full = options.profile.name;
   body.lis_person_name_given = first;
   body.lis_person_sourcedid = options.profile.login_id;
+  body.lis_course_offering_sourcedid = options.course.sis_id;
   body.lti_message_type = 'basic-lti-launch-request';
   body.lti_version = 'LTI-1p0';
   body.oauth_callback = 'about:blank';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-authorizer",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-authorizer",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "Acquires Canvas tokens through via OAuth, stores refresh tokens, and refreshes access tokens when they expire.",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/harvard-edtech/caccl-token-manager#readme",
   "devDependencies": {
     "body-parser": "^1.19.0",
-    "caccl": "^1.1.36",
+    "caccl": "^1.1.41",
     "caccl-canvas-partial-simulator": "^1.0.43",
     "dce-selenium": "^1.0.58",
     "eslint": "^5.16.0",

--- a/test/helpers/addAppRoutes.js
+++ b/test/helpers/addAppRoutes.js
@@ -361,6 +361,16 @@ module.exports = (app, config) => {
           pass
         );
 
+        // LIS identifier for the course offering,
+        // Also called sis_course_id, sis_id, and ssid in Canvas
+        pass = (req.body.lis_course_offering_sourcedid === course.sis_id);
+        addRow(
+          'lis_course_offering_sourcedid',
+          'Equals LIS identifier for the course offering',
+          `Should be ${course.sis_id}`,
+          pass
+        );
+
         // lti_message_type: 'basic-lti-launch-request',
         pass = (req.body.lti_message_type === 'basic-lti-launch-request');
         addRow(


### PR DESCRIPTION
GATHER-184 updating package-lock with feature branch caccl-<lib>
1.1.26
Adjust var name and update patch version

NOTE: CACCL 1.1.41 is the current release, 1.1.42 has the course sis_id